### PR TITLE
fix(contribute.md): correct format for allowed/example vals for msgs

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -37,29 +37,29 @@
 
     **Message subject**
 
-    First line cannot be longer than 70 characters, second line is always blank and other lines should be wrapped at 80 characters. 
+    First line cannot be longer than 70 characters, second line is always blank and other lines should be wrapped at 80 characters.
 
     The *type* and *scope* should always be lowercase as shown below.
 
-    ***Allowed <type> values:***
+    ***Allowed type values:***
 
-    **feat** (new feature for the user, not a new feature for build script)
-    **fix** (bug fix for the user, not a fix to a build script)
-    **docs** (changes to the documentation)
-    **style** (formatting, missing semi colons, etc; no production code change)
-    **refactor** (refactoring production code, eg. renaming a variable)
-    **test** (adding missing tests, refactoring tests; no production code change)
-    **chore** (updating grunt tasks etc; no production code change)
+    - **feat** (new feature for the user, not a new feature for build script)
+    - **fix** (bug fix for the user, not a fix to a build script)
+    - **docs** (changes to the documentation)
+    - **style** (formatting, missing semi colons, etc; no production code change)
+    - **refactor** (refactoring production code, eg. renaming a variable)
+    - **test** (adding missing tests, refactoring tests; no production code change)
+    - **chore** (updating grunt tasks etc; no production code change)
 
-    ***Example <scope> values:***
+    ***Example scope values:***
 
-    init
-    runner
-    watcher
-    config
-    web-server
-    proxy
-    etc.
+    - init
+    - runner
+    - watcher
+    - config
+    - web-server
+    - proxy
+    - etc.
 
     The *scope* can be empty (eg. if the change is a global or difficult to assign to a single component), in which case the parentheses are omitted. In smaller projects such as Karma plugins, the <scope> is empty.
 


### PR DESCRIPTION
Fixed formatting issues on the message commit section. The markdown previewer I use did not render the same as github.
